### PR TITLE
liskov & Interface segregation

### DIFF
--- a/src/main/java/com/company/intersegrega/entity/Entity.java
+++ b/src/main/java/com/company/intersegrega/entity/Entity.java
@@ -1,0 +1,17 @@
+package com.company.intersegrega.entity;
+
+//Base class for all entities
+public abstract class Entity {
+	
+	private Long id;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+	
+	
+}

--- a/src/main/java/com/company/intersegrega/entity/Order.java
+++ b/src/main/java/com/company/intersegrega/entity/Order.java
@@ -1,0 +1,28 @@
+package com.company.intersegrega.entity;
+
+import java.time.LocalDateTime;
+
+//Order entity class
+public class Order extends Entity {
+
+	private LocalDateTime orderPlacedOn;
+	
+	private double totalValue;
+
+	public LocalDateTime getOrderPlacedOn() {
+		return orderPlacedOn;
+	}
+
+	public void setOrderPlacedOn(LocalDateTime orderPlacedOn) {
+		this.orderPlacedOn = orderPlacedOn;
+	}
+
+	public double getTotalValue() {
+		return totalValue;
+	}
+
+	public void setTotalValue(double totalValue) {
+		this.totalValue = totalValue;
+	}
+	
+}

--- a/src/main/java/com/company/intersegrega/entity/User.java
+++ b/src/main/java/com/company/intersegrega/entity/User.java
@@ -1,0 +1,27 @@
+package com.company.intersegrega.entity;
+
+import java.time.LocalDateTime;
+
+public class User extends Entity{
+	
+	private String name;
+	
+	private LocalDateTime lastLogin;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public LocalDateTime getLastLogin() {
+		return lastLogin;
+	}
+
+	public void setLastLogin(LocalDateTime lastLogin) {
+		this.lastLogin = lastLogin;
+	}
+	
+}

--- a/src/main/java/com/company/intersegrega/service/OrderPersistenceService.java
+++ b/src/main/java/com/company/intersegrega/service/OrderPersistenceService.java
@@ -1,0 +1,38 @@
+package com.company.intersegrega.service;
+
+import com.company.intersegrega.entity.Order;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OrderPersistenceService implements PersistenceService<Order> {
+    private static final Map<Long, Order> ORDERS = new HashMap<>();
+
+    @Override
+    public void save(Order entity) {
+        synchronized (ORDERS) {
+            ORDERS.put(entity.getId(), entity);
+        }
+    }
+
+    @Override
+    public void delete(Order entity) {
+        synchronized (ORDERS) {
+            ORDERS.remove(entity.getId());
+        }
+    }
+
+    @Override
+    public Order findById(Long id) {
+        synchronized (ORDERS) {
+            return ORDERS.get(id);
+        }
+    }
+
+    @Override
+    public List<Order> findByName(String name) {
+        // Instead of implementing interface method, remove it from interface.
+        throw new UnsupportedOperationException("Find by name is not supported");
+    }
+}

--- a/src/main/java/com/company/intersegrega/service/PersistenceService.java
+++ b/src/main/java/com/company/intersegrega/service/PersistenceService.java
@@ -1,0 +1,17 @@
+package com.company.intersegrega.service;
+
+import java.util.List;
+
+import com.company.intersegrega.entity.Entity;
+
+//common interface to be implemented by all persistence services. 
+public interface PersistenceService<T extends Entity> {
+
+	public void save(T entity);
+	
+	public void delete(T entity);
+	
+	public T findById(Long id);
+	
+	public List<T> findByName(String name);
+}

--- a/src/main/java/com/company/intersegrega/service/UserPersistenceService.java
+++ b/src/main/java/com/company/intersegrega/service/UserPersistenceService.java
@@ -1,0 +1,43 @@
+package com.company.intersegrega.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.company.intersegrega.entity.User;
+
+//Stores User entities
+public class UserPersistenceService implements PersistenceService<User>{
+	
+	private static final Map<Long, User> USERS = new HashMap<>();
+	
+	@Override
+	public void save(User entity) {
+		synchronized (USERS) {
+			USERS.put(entity.getId(), entity);
+		}
+	}
+
+	@Override
+	public void delete(User entity) {
+		synchronized (USERS) {
+			USERS.remove(entity.getId());
+		}
+	}
+
+	@Override
+	public User findById(Long id) {
+		synchronized (USERS) {
+			return USERS.get(id);
+		}
+	}
+	
+	@Override
+	public List<User> findByName(String name) {
+		synchronized (USERS) {
+			return USERS.values().stream().filter(u->u.getName().equalsIgnoreCase(name)).collect(Collectors.toList());
+		}
+	}
+
+}

--- a/src/main/java/com/company/liskov_1/LiskovMain.java
+++ b/src/main/java/com/company/liskov_1/LiskovMain.java
@@ -1,0 +1,25 @@
+package com.company.liskov_1;
+
+public class LiskovMain {
+
+	public static void main(String[] args) {
+		
+		Rectangle rectangle = new Rectangle(10, 20);
+		System.out.println(rectangle.computeArea());
+		
+		Square square = new Square(10);
+		System.out.println(square.computeArea());
+		
+		useRectangle(rectangle);
+		
+		//useRectangle(square);
+
+	}
+
+	private static void useRectangle(Rectangle rectangle) {
+		rectangle.setHeight(20);
+		rectangle.setWidth(30);
+		assert rectangle.getHeight() == 20 : "Height Not equal to 20";
+		assert rectangle.getWidth() == 30 : "Width Not equal to 30";
+	}
+}

--- a/src/main/java/com/company/liskov_1/Rectangle.java
+++ b/src/main/java/com/company/liskov_1/Rectangle.java
@@ -1,0 +1,33 @@
+package com.company.liskov_1;
+
+public class Rectangle implements Shape{
+
+	private int width;
+	
+	private int height;
+
+	public Rectangle(int width, int height) {
+		this.width = width;
+		this.height = height;
+	}
+
+	public int getWidth() {
+		return width;
+	}
+
+	public void setWidth(int width) {
+		this.width = width;
+	}
+
+	public int getHeight() {
+		return height;
+	}
+
+	public void setHeight(int height) {
+		this.height = height;
+	}
+	
+	public int computeArea() {
+		return width * height;
+	}
+}

--- a/src/main/java/com/company/liskov_1/Shape.java
+++ b/src/main/java/com/company/liskov_1/Shape.java
@@ -1,0 +1,5 @@
+package com.company.liskov_1;
+
+public interface Shape {
+    public int computeArea();
+}

--- a/src/main/java/com/company/liskov_1/Square.java
+++ b/src/main/java/com/company/liskov_1/Square.java
@@ -1,0 +1,21 @@
+package com.company.liskov_1;
+
+public class Square implements Shape {
+	private int side;
+	
+	public Square(int side) {
+		this.side = side;
+	}
+	public int computeArea() {
+		return side * side;
+	}
+
+	public void setSide(int side) {
+		this.side = side;
+	}
+
+	public int getSide() {
+		return side;
+	}
+
+}


### PR DESCRIPTION
**1. Liskov Substitution Principle**
We should be to substitute base class objects with child class objects & this substitution should not alter behavior / characteristics of the program.

- Add VM option in Intellij
<img width="706" alt="add-VM-option-ea" src="https://github.com/user-attachments/assets/5db42ceb-0a10-47ca-b03f-d316171f13b9" />

- assertion test
After setting configuration, run main(LiskovMain) java code.
so that assertion is executed and result becomes failure.
<img width="764" alt="assertion-failure" src="https://github.com/user-attachments/assets/69873c6f-7b98-467c-b266-3dfb00628973" />

When we see Square class, it inherits Rectangle class and override setWidth and setHeight.
- Square Class
<img width="460" alt="Square_clas" src="https://github.com/user-attachments/assets/ce413e18-009c-4118-98e1-8f8b046618b6" />

either setHeight or setWidth is called then same value is set in both of width and height.
Rectangle evaluation is fine (hight:20, width:30)
Square evaluation case: Height is 30 instead of 20. because setWidth(30) sets hight == 30 too.

This violate Liskov substitution principle.
How to fix: break relationship (Square extends Rectangle) & create interface
↓
two classes Rectangle and Square do not have a direct relationship, but both implement the same interface called shape.


**2. Interface Segregation Principle**
Clients should not be forced to depend upon interfaces that they do not use.
- Interface Pollution
  - Large Interfaces
  - Unrelated Methods

- Signs of Interface Pollution
  - Classes have empty method implementations
  - Method implementations throw UnsupportedOperationException (or similar)
  - Method implementations return null or default/dummy values 

