### PR TITLE
after dependency inversion

### DIFF
--- a/src/main/java/com/company/depinv/DependencyInversionMain.java
+++ b/src/main/java/com/company/depinv/DependencyInversionMain.java
@@ -1,6 +1,8 @@
 package com.company.depinv;
 
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
 
 public class DependencyInversionMain {
 
@@ -8,7 +10,10 @@ public class DependencyInversionMain {
 		
 		Message msg = new Message("This is a message again");
 		MessagePrinter printer = new MessagePrinter();
-		printer.writeMessage(msg, "test_msg.txt");
+		try(PrintWriter writer = new PrintWriter(new FileWriter("test_msg.txt"))) {
+			printer.writeMessage(msg, new JSONFormatter(), writer);
+		}
+
 	}
 
 }

--- a/src/main/java/com/company/depinv/MessagePrinter.java
+++ b/src/main/java/com/company/depinv/MessagePrinter.java
@@ -7,11 +7,9 @@ import java.io.PrintWriter;
 public class MessagePrinter {
 
 	//Writes message to a file
-	public void writeMessage(Message msg, String fileName) throws IOException {
-		Formatter formatter = new JSONFormatter();//creates formatter
-		try(PrintWriter writer = new PrintWriter(new FileWriter(fileName))) { //creates print writer
-			writer.println(formatter.format(msg)); //formats and writes message
-			writer.flush();
-		}
+	public void writeMessage(Message msg, Formatter formatter, PrintWriter writer) throws IOException {
+
+		writer.println(formatter.format(msg)); //formats and writes message
+		writer.flush();
 	}
 }


### PR DESCRIPTION
**Dependency Inversion Principle**
- High level modules should not depend on low level modules. Both should depend on abstractions.
- Abstractions should not depend on details. Details should depend on abstractions.

 Instead of creating a new instance of Object Mapper or creating new instance of file writer, we can use an interface called as, let's say, writer, another interface called as Formatter.
And we will write our high level module code using that interface. It means we will accept parameters of particular interfaces.
The benefit is that our code is no longer tightly coupled to any concrete class.

as you can see, the dependencies for the writeMessage that we can immediately find out is that it depends on Json formatter and it depends on the print writer. 
Now this print writer is part of Java’s IO package, but nonetheless, this is a dependency of this particular message.

<img width="660" alt="writerMessage" src="https://github.com/user-attachments/assets/9b62ca68-602e-47be-b6e7-5ff0210732b4" />

What is the problem of implementation ?
Let's say if we want to print this message on console, then the current method is not going to work unless we go and write another method where instead of using print writer, we use system.out. This is the first problem.

Second problem is that if we want to change the format of the message, we have to modify again this particular method and change the Json formatter to the new class that we want to use to format our message object.


```Java
public void writeMessage(Message msg, String fileName, Formatter formatter, PrintWriter writer) throws IOException {
	writer.println(formatter.format(msg));
	writer.flush();
}
```

So now instead of creating the Json formatter, we are accepting a parameter.
So we are declaring our dependency and we’re asking our caller to give us the dependency.
So the responsibility of creating the actual object of the dependency is now with the client or caller of this writeMessage.

- Output 

```Java
try(PrintWriter writer = new PrintWriter(new FileWriter("test_msg.txt"))) {
			printer.writeMessage(msg, new JSONFormatter(), writer);
		}
```
We can change how to output with system out instead of new `FileWriter("test_msg.txt")`.

<img width="575" alt="different-output-sys out" src="https://github.com/user-attachments/assets/84aedc66-63aa-472c-b045-2e896ddf7214" />



