### PR TITLE
Implement Abstract Factory

### DIFF
--- a/src/main/java/com/company/abstractfactory2/Client.java
+++ b/src/main/java/com/company/abstractfactory2/Client.java
@@ -2,11 +2,45 @@ package com.company.abstractfactory2;
 
 import com.company.abstractfactory2.aws.AwsResourceFactory;
 import com.company.abstractfactory2.gcp.GoogleResourceFactory;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 public class Client {
+    private ResourceFactory factory;
 
-    public static void main(String[] args) {
-    	
+    public Client(ResourceFactory factory) {
+        this.factory = factory;
+    }
+
+    public Instance createServer(Instance.Capacity cap, int storageMib) {
+        Instance instance = factory.createInstance(cap);
+        Storage storage = factory.createStorage(storageMib);
+        instance.attachStorage(storage);
+        return instance;
+    }
+
+    public static void main(String[] args) throws Exception{
+    	Client aws = new Client(new AwsResourceFactory());
+        Instance i1 = aws.createServer(Instance.Capacity.micro, 20480);
+        i1.start();
+        i1.stop();
+
+        Client gcp = new Client(new GoogleResourceFactory());
+        Instance i2 = gcp.createServer(Instance.Capacity.large, 408000);
+        i2.start();
+        i2.stop();
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        System.out.println("Using factory class: " + factory.getClass());
+
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        System.out.println("Got builder class: " + builder.getClass());
+
+        Document doc = builder.newDocument();
+        System.out.println("Got Document class: " + doc.getClass());
+
     }
 
 }

--- a/src/main/java/com/company/abstractfactory2/ResourceFactory.java
+++ b/src/main/java/com/company/abstractfactory2/ResourceFactory.java
@@ -2,5 +2,7 @@ package com.company.abstractfactory2;
 
 //Abstract factory with methods defined for each object type.
 public interface ResourceFactory {
+    Instance createInstance(Instance.Capacity capacity);
+    Storage createStorage(int capMib);
 
 }

--- a/src/main/java/com/company/abstractfactory2/aws/AwsResourceFactory.java
+++ b/src/main/java/com/company/abstractfactory2/aws/AwsResourceFactory.java
@@ -7,4 +7,13 @@ import com.company.abstractfactory2.Storage;
 public class AwsResourceFactory implements ResourceFactory {
 
 
+    @Override
+    public Instance createInstance(Instance.Capacity capacity) {
+        return new Ec2Instance(capacity);
+    }
+
+    @Override
+    public Storage createStorage(int capMib) {
+        return new S3Storage(capMib);
+    }
 }

--- a/src/main/java/com/company/abstractfactory2/gcp/GoogleResourceFactory.java
+++ b/src/main/java/com/company/abstractfactory2/gcp/GoogleResourceFactory.java
@@ -8,4 +8,13 @@ import com.company.abstractfactory2.Storage;
 public class GoogleResourceFactory implements ResourceFactory {
 
 
+    @Override
+    public Instance createInstance(Instance.Capacity capacity) {
+        return new GoogleComputeEngineInstance(capacity);
+    }
+
+    @Override
+    public Storage createStorage(int capMib) {
+        return new GoogleCloudStorage(capMib);
+    }
 }


### PR DESCRIPTION
### Abstract Factory Overview
- Abstract factory is used when we have two or more objects which work together forming a kit or set and there can be multiple sets or kits that can be created by client code.
- So we separate client code from concrete objects forming such a set and also from the code which creates these sets.

### Add implementation
- Implement two classes ` AwsResourceFactory`  and `GoogleResourceFactory` which implement `ResourceFactory` 
- provide the client code with a concrete factory so that it can create objects.

```Java
    public Client(ResourceFactory factory) {
        this.factory = factory;
    }

    public Instance createServer(Instance.Capacity cap, int storageMib) {
        Instance instance = factory.createInstance(cap);
        Storage storage = factory.createStorage(storageMib);
        instance.attachStorage(storage);
        return instance;
    }
```