### PR TITLE
Feature07 singleton

### DIFF
--- a/src/main/java/com/company/singleton/Client.java
+++ b/src/main/java/com/company/singleton/Client.java
@@ -9,5 +9,9 @@ public class Client {
         LazyRegistryWithDCL lazySingleton1 = LazyRegistryWithDCL.getInstance();
         LazyRegistryWithDCL lazySingleton2 = LazyRegistryWithDCL.getInstance();
         System.out.println(lazySingleton1 == lazySingleton2);
+
+        LazyRegistryIODH singleton;
+        singleton = LazyRegistryIODH.getInstance();
+        singleton = LazyRegistryIODH.getInstance();
     }
 }

--- a/src/main/java/com/company/singleton/Client.java
+++ b/src/main/java/com/company/singleton/Client.java
@@ -1,0 +1,13 @@
+package com.company.singleton;
+
+public class Client {
+    public static void main(String[] args) {
+        EagerRegistry registry = EagerRegistry.getInstance();
+        EagerRegistry registry2 = EagerRegistry.getInstance();
+        System.out.println(registry == registry2);
+
+        LazyRegistryWithDCL lazySingleton1 = LazyRegistryWithDCL.getInstance();
+        LazyRegistryWithDCL lazySingleton2 = LazyRegistryWithDCL.getInstance();
+        System.out.println(lazySingleton1 == lazySingleton2);
+    }
+}

--- a/src/main/java/com/company/singleton/EagerRegistry.java
+++ b/src/main/java/com/company/singleton/EagerRegistry.java
@@ -1,0 +1,11 @@
+package com.company.singleton;
+
+public class EagerRegistry {
+    private EagerRegistry() {}
+
+    private static final EagerRegistry INSTANCE = new EagerRegistry();
+
+    public static EagerRegistry getInstance() {
+        return INSTANCE;
+    }
+}

--- a/src/main/java/com/company/singleton/LazyRegistryIODH.java
+++ b/src/main/java/com/company/singleton/LazyRegistryIODH.java
@@ -1,0 +1,19 @@
+package com.company.singleton;
+
+/*
+Singleton pattern using lazy initialization holder class.
+This class ensure that we have a lazy initialization without worrying about synchronization.
+* */
+public class LazyRegistryIODH {
+    private LazyRegistryIODH () {
+        System.out.println("In LazyRegistryIODH singleton");
+    }
+
+    private static class RegistryHolder {
+        static LazyRegistryIODH INSTANCE = new LazyRegistryIODH();
+    }
+
+    public static LazyRegistryIODH getInstance() {
+        return RegistryHolder.INSTANCE;
+    }
+}

--- a/src/main/java/com/company/singleton/LazyRegistryWithDCL.java
+++ b/src/main/java/com/company/singleton/LazyRegistryWithDCL.java
@@ -1,0 +1,18 @@
+package com.company.singleton;
+
+public class LazyRegistryWithDCL {
+    private LazyRegistryWithDCL() {}
+
+    private static volatile LazyRegistryWithDCL INSTANCE;
+
+    public static LazyRegistryWithDCL getInstance() {
+        if (INSTANCE == null) {
+            synchronized (LazyRegistryWithDCL.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new LazyRegistryWithDCL();
+                }
+            }
+        }
+        return INSTANCE;
+    }
+}

--- a/src/main/java/com/company/singleton/RegistryEnum.java
+++ b/src/main/java/com/company/singleton/RegistryEnum.java
@@ -1,0 +1,12 @@
+package com.company.singleton;
+
+/*
+* (Ref. Google I/O 2k8 Joshua Bloch)
+* Since Java 1.5 using enum we can create a singleton. It handles serialization using Java's in-built
+* mechanism and still ensure single instance.
+* */
+public enum RegistryEnum {
+    INSTANCE;
+
+    public void getConfiguration() {}
+}


### PR DESCRIPTION
1. Eager Singleton
```Java
EagerRegistry registry = EagerRegistry.getInstance();
EagerRegistry registry2 = EagerRegistry.getInstance();
System.out.println(registry == registry2);
```
In Client class, this result becomes true.

2. Lazy Singleton
```Java
    private static volatile LazyRegistryWithDCL INSTANCE;

    public static LazyRegistryWithDCL getInstance() {
        if (INSTANCE == null) {
            synchronized (LazyRegistryWithDCL.class) {
                if (INSTANCE == null) {
                    INSTANCE = new LazyRegistryWithDCL();
                }
            }
        }
        return INSTANCE;
    }
```
- when multiple threads are referring to a variable, then it is quite common that these threads will cash the value of this variable in one of the registered CPU.
- To overcome that, Java has provided us with a keyword called this volatile. it will indicate to these threats that they should not use the cached version of this variable's value.
- So every time they want to access the instance value, they will refer to the main memory and that we can ensure or we can guarantee that both of these threats that are coming to our synchronize log will get the latest value that is present.

3. Lazy Initialization On Demand Holder (IODH)
```Java
        LazyRegistryIODH singleton;
        singleton = LazyRegistryIODH.getInstance();
        singleton = LazyRegistryIODH.getInstance();

```
- When getInstance() is called for the first time, the JVM loads the RegistryHolder class. As part of this loading process, the INSTANCE variable is initialized, which creates the singleton instance. The message In LazyRegistryIODH singleton is printed.
- At second time, the RegistryHolder class has already been loaded, so the INSTANCE variable is directly returned without creating a new instance. No new message is printed.

```Java
private static class RegistryHolder {
    static LazyRegistryIODH INSTANCE = new LazyRegistryIODH();
}
```
- The RegistryHolder class is static and only contains a single static variable INSTANCE that holds the singleton instance of LazyRegistryIODH.
- This static variable is initialized when the RegistryHolder class is loaded by the JVM.

4. Enum 
- We can use enum but it can rarely be seen
- The best preferred way is lazy initialization holder because this pattern provides you best of both worlds.
