### PR TITLE
Feature16 chain of responsibility

### DIFF
--- a/src/main/java/com/company/behavioral/chainofresponsibility/Client.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/Client.java
@@ -1,0 +1,26 @@
+package com.company.behavioral.chainofresponsibility;
+
+import java.time.LocalDate;
+
+public class Client {
+    public static void main(String[] args) {
+        LeaveApplication application = LeaveApplication.getBuilder()
+                .withType(LeaveApplication.Type.Sick)
+                .from(LocalDate.now())
+                .to(LocalDate.of(2025, 1, 22))
+                .build();
+        System.out.println(application);
+        System.out.println("****************************************");
+
+        LeaveApprover approver = createChain();
+        approver.processLeaveApplication(application);
+        System.out.println(application);
+    }
+
+    private static LeaveApprover createChain() {
+        Director director = new Director(null);
+        Manager manager = new Manager(director);
+        ProjectLead lead = new ProjectLead(manager);
+        return lead;
+    }
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/Director.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/Director.java
@@ -1,0 +1,16 @@
+package com.company.behavioral.chainofresponsibility;
+
+public class Director extends Employee {
+    public Director(LeaveApprover nextApprover) {
+        super("Director", nextApprover);
+    }
+
+    @Override
+    protected boolean processRequest(LeaveApplication application) {
+        if (application.getType() == LeaveApplication.Type.PTO) {
+            application.approve(getApproverRole());
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/Employee.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/Employee.java
@@ -1,0 +1,25 @@
+package com.company.behavioral.chainofresponsibility;
+
+public abstract class Employee implements LeaveApprover {
+    private String role;
+    private LeaveApprover successor;
+
+    public Employee(String role, LeaveApprover successor) {
+        this.role = role;
+        this.successor = successor;
+    }
+
+    @Override
+    public void processLeaveApplication(LeaveApplication application) {
+        if (!processRequest(application) && successor != null) {
+            successor.processLeaveApplication(application);
+        }
+    }
+
+    protected abstract boolean processRequest(LeaveApplication leaveApplication);
+
+    @Override
+    public String getApproverRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/LeaveApplication.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/LeaveApplication.java
@@ -1,0 +1,85 @@
+package com.company.behavioral.chainofresponsibility;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class LeaveApplication {
+    public enum Type {Sick, PTO, LOP};
+    public enum Status {Pending, Approved, Rejected};
+    private Type type;
+    private LocalDate from;
+    private LocalDate to;
+    private String processedBy;
+    private Status status;
+
+    public LeaveApplication(Type type, LocalDate from, LocalDate to) {
+        this.type = type;
+        this.from = from;
+        this.to = to;
+        this.status = Status.Pending;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Long getNoOfDays() {
+        return ChronoUnit.DAYS.between(from, to);
+    }
+
+    public void approve(String approverName) {
+        System.out.println(approverName + " approved");
+        this.status = Status.Approved;
+        this.processedBy = approverName;
+    }
+
+    public void reject(String approverName) {
+        this.status = Status.Rejected;
+        this.processedBy = approverName;
+    }
+
+    public static Builder getBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder{
+        private Type type;
+        private LocalDate from;
+        private LocalDate to;
+        private LeaveApplication application;
+
+        private Builder() {
+
+        }
+
+        public Builder withType(Type type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder from(LocalDate from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder to(LocalDate to) {
+            this.to = to;
+            return this;
+        }
+
+        public LeaveApplication build() {
+            this.application = new LeaveApplication(type, from, to);
+            return this.application;
+        }
+
+        public LeaveApplication getApplication() {
+            return application;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return type + " leave for "+getNoOfDays()+" day(s) "+status
+                + " by "+processedBy;
+    }
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/LeaveApprover.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/LeaveApprover.java
@@ -1,0 +1,7 @@
+package com.company.behavioral.chainofresponsibility;
+
+public interface LeaveApprover {
+    void processLeaveApplication(LeaveApplication leaveApplication);
+
+    String getApproverRole();
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/Manager.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/Manager.java
@@ -1,0 +1,22 @@
+package com.company.behavioral.chainofresponsibility;
+
+public class Manager extends Employee {
+    public Manager(LeaveApprover nextApprover) {
+        super("Manager", nextApprover);
+    }
+
+    @Override
+    protected boolean processRequest(LeaveApplication application) {
+        switch (application.getType()) {
+            case Sick:
+                application.approve(getApproverRole());
+                return true;
+            case PTO:
+                if (application.getNoOfDays() <= 5) {
+                    application.approve(getApproverRole());
+                    return true;
+                }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/company/behavioral/chainofresponsibility/ProjectLead.java
+++ b/src/main/java/com/company/behavioral/chainofresponsibility/ProjectLead.java
@@ -1,0 +1,19 @@
+package com.company.behavioral.chainofresponsibility;
+
+public class ProjectLead extends Employee {
+    public ProjectLead(LeaveApprover successor) {
+        super("Project Lead", successor);
+    }
+
+    @Override
+    protected boolean processRequest(LeaveApplication application) {
+        //type is sick leave & duration is less than or equal to 2 days
+        if (application.getType() == LeaveApplication.Type.Sick) {
+            if (application.getNoOfDays() <= 2) {
+                application.approve(getApproverRole());
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/company/structural/proxy/Client.java
+++ b/src/main/java/com/company/structural/proxy/Client.java
@@ -1,0 +1,11 @@
+package com.company.structural.proxy;
+
+public class Client {
+    public static void main(String[] args) {
+        Image img = ImageFactory.getImage("A1.bmp");
+        img.setLocation(new Point2D(10, 10));
+        System.out.println("Image Location :" + img.getLocation());
+        System.out.println("Rendering image now...");
+        img.render();
+    }
+}

--- a/src/main/java/com/company/structural/proxy/ImageFactory.java
+++ b/src/main/java/com/company/structural/proxy/ImageFactory.java
@@ -1,4 +1,7 @@
 package com.company.structural.proxy;
 
 public class ImageFactory {
+    public static Image getImage(String name) {
+        return new ImageProxy(name);
+    }
 }

--- a/src/main/java/com/company/structural/proxy/ImageProxy.java
+++ b/src/main/java/com/company/structural/proxy/ImageProxy.java
@@ -1,4 +1,38 @@
 package com.company.structural.proxy;
 
-public class ImageProxy {
+public class ImageProxy implements Image {
+    private String name;
+    private BitmapImage image;
+    private Point2D location;
+
+    public ImageProxy(String name) {
+        this.name = name;
+    }
+    @Override
+    public void setLocation(Point2D point2D) {
+        if (image != null) {
+            image.setLocation(point2D);
+        } else {
+            location = point2D;
+        }
+    }
+
+    @Override
+    public Point2D getLocation() {
+        if (image != null) {
+            return image.getLocation();
+        }
+        return location;
+    }
+
+    @Override
+    public void render() {
+        if (image == null) {
+            image = new BitmapImage(name);
+            if (location != null) {
+                image.setLocation(location);
+            }
+        }
+        image.render();
+    }
 }


### PR DESCRIPTION
### Chain of Responsibility Overview
- We need to avoid coupling the code which sends request to the code which handles that request.
- Typically the code which wants some request handled calls the exact method on an exact object to process it, thus the tight coupling. Chain of responsibility solves this problem by giving more than one object, chance to process the request.
- We create objects which are chained together by one object knowing the reference of the object which is next in the chain. We give request to first object in chain, if it can’t handle it simply passes the request down the chain.

### Implement Chain of Responsibility
- Handler must define a method to accept incoming request
- Handler can define a method to access the successor in the chain. If it’s an abstract class then we can even maintain a successor.
- Next we implement a handler in one or more concrete handlers. Concrete handler should check if it can handle the request. If not then it should pass the request to the next handler.
- We have to create our chain of objects next. We can do it on the client. Typically in the real world this job will be done by some framework or initialization code written by you.
- Client needs to know only the first object in chain. It’ll pass on request to this object.


1. Handler: `LeaveApprover` interface
2. Abstract Handler: abstract `Employee` implements `LeaveApprover` 
3. Concrete Handler: `ProjectLead` extends `Employee`
4. Setup chain of responsibility in Client 
```Java
    private static LeaveApprover createChain() {
        Director director = new Director(null);
        Manager manager = new Manager(director);
        ProjectLead lead = new ProjectLead(manager);
        return lead;
    }
```

